### PR TITLE
Login link fix in register.html page

### DIFF
--- a/src/pug/pages/register.pug
+++ b/src/pug/pages/register.pug
@@ -34,4 +34,4 @@ block content
                                 a.btn.btn-primary.btn-block(href='login.html') Create Account
                     .card-footer.text-center
                         .small
-                            a(href='register.html') Have an account? Go to login
+                            a(href='login.html') Have an account? Go to login


### PR DESCRIPTION
From `register.html` page, Going back to login page link was incorrect. That's fixed